### PR TITLE
Update index.ts

### DIFF
--- a/src/core/consumer/index.ts
+++ b/src/core/consumer/index.ts
@@ -158,12 +158,15 @@ export class Consumer extends SDKBase {
       assert(options.registry || options.serverHosts, 'rpcClient.createConsumer(options) 需要指定 options.serverHosts');
     }
 
+    let defaultBeforeInvoke = providerList => Discoverer.checkEnvOrGroup(providerList, null, this.options.group, []);
+
     async invoke(method, args, headers = [], options: InvokeOptions = {
-      beforeInvoke: providerList => Discoverer.checkEnvOrGroup(providerList, null, this.options.group, []),
+      beforeInvoke: defaultBeforeInvoke,
       rpcMsgId: 1
     }) {
       options.__trace && options.__trace.start();
 
+      options.beforeInvoke = options.beforeInvoke || defaultBeforeInvoke;
       this.serverAddress = options.beforeInvoke(this.providerList, this.options, Discoverer) || [];
 
       if (this.serverAddress.length === 0) {


### PR DESCRIPTION
invoke方法的options默认参数值设置存在bug。
如果使用者，没有传options则没事；一旦传了不包括beforeInvoke属性的options，默认值又不会生效，便会报错。

而README中例子恰恰就是不包括beforeInvoke属性的options。